### PR TITLE
subway api statusCode 200, 500 구분 안되는 문제 해결

### DIFF
--- a/lib/data/api/mock_subway_api.dart
+++ b/lib/data/api/mock_subway_api.dart
@@ -4,7 +4,7 @@ import 'package:real_time_subway/data/dto/subway_real_time_info_dto/subway_real_
 
 class MockSubwayApi implements SubwayApi {
   @override
-  Future<SubwayRealTimeInfoDto> getRealTimeSubwayInfo(String station) async {
+  Future<SubwayRealTimeInfoDto?> getRealTimeSubwayInfo(String station) async {
     await Future.delayed(const Duration(seconds: 2));
 
     String? jsonData;

--- a/lib/data/api/subway_api.dart
+++ b/lib/data/api/subway_api.dart
@@ -1,5 +1,5 @@
 import 'package:real_time_subway/data/dto/subway_real_time_info_dto/subway_real_time_info_dto.dart';
 
 abstract interface class SubwayApi {
-  Future<SubwayRealTimeInfoDto> getRealTimeSubwayInfo(String station);
+  Future<SubwayRealTimeInfoDto?> getRealTimeSubwayInfo(String station);
 }

--- a/lib/data/api/subway_api_impl.dart
+++ b/lib/data/api/subway_api_impl.dart
@@ -8,20 +8,20 @@ class SubwayApiImpl implements SubwayApi {
   final String _baseUrl = 'http://swopenapi.seoul.go.kr/api/subway';
 
   @override
-  Future<SubwayRealTimeInfoDto> getRealTimeSubwayInfo(String station) async {
+  Future<SubwayRealTimeInfoDto?> getRealTimeSubwayInfo(String station) async {
     try {
-      final response = await http.get(Uri.parse(
-          '$_baseUrl/$_apiKey/json/realtimeStationArrival/0/5/$station'));
-
-      if (response.statusCode == 200) {
-        final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
-        final dto = SubwayRealTimeInfoDto.fromJson(jsonData);
-        return dto;
-      } else if (response.statusCode == 500) {
-        throw Exception('해당하는 데이터가 없습니다 (역 이름 다시 확인 필요)');
-      } else {
-        throw Exception('데이터를 가져오는데 실패했습니다. 상태 코드: ${response.statusCode}');
+      final response = await http.get(
+        Uri.parse(
+            '$_baseUrl/$_apiKey/json/realtimeStationArrival/0/5/$station'),
+      );
+      final jsonData = jsonDecode(utf8.decode(response.bodyBytes));
+      if (jsonData['status'] == 500) {
+        return null;
       }
+      if (jsonData['errorMessage']['status'] == 200) {
+        return SubwayRealTimeInfoDto.fromJson(jsonData);
+      }
+      throw Exception('데이터를 가져오는데 실패했습니다. 상태 코드: ${jsonData['status']}');
     } catch (error) {
       throw Exception('지하철 실시간 정보 로딩 중 오류가 발생했습니다: $error');
     }

--- a/lib/data/repository/subway_repository_impl.dart
+++ b/lib/data/repository/subway_repository_impl.dart
@@ -1,20 +1,20 @@
 import 'package:real_time_subway/data/api/subway_api.dart';
-import 'package:real_time_subway/data/dto/subway_real_time_info_dto/subway_real_time_info_dto.dart';
 import 'package:real_time_subway/data/mapper/subway_real_time_info_mapper.dart';
 import 'package:real_time_subway/domain/model/subway_real_time_info.dart';
 import 'package:real_time_subway/domain/repository/subway_repository.dart';
 
 class SubwayRepositoryImpl implements SubwayRepository {
   final SubwayApi _api;
+
   SubwayRepositoryImpl(this._api);
+
   @override
   Future<List<SubwayRealTimeInfo>> getSubwayInfo(String station) async {
-    SubwayRealTimeInfoDto dto = await _api.getRealTimeSubwayInfo(station);
+    final dto = await _api.getRealTimeSubwayInfo(station);
 
-    List<SubwayRealTimeInfo> subwayInfoList = dto.realtimeArrivalList
-            ?.map((realtimeArrival) => realtimeArrival.toSubwayRealTimeInfo())
+    return dto?.realtimeArrivalList
+            ?.map((arrival) => arrival.toSubwayRealTimeInfo())
             .toList() ??
         [];
-    return subwayInfoList;
   }
 }

--- a/lib/presentation/subway/subway_screen.dart
+++ b/lib/presentation/subway/subway_screen.dart
@@ -37,18 +37,28 @@ class _SubwayScreenState extends State<SubwayScreen> {
             Expanded(
               child: viewModel.state.isLoading
                   ? const Center(child: CircularProgressIndicator())
-                  : ListView(
-                      children: viewModel.state.subwayInfos
-                          .map(
-                            (subway) => SubwayInfoListTile(
-                              subwayLine: subway.subwayLine.name,
-                              direction: subway.direction,
-                              arrivalMsg: subway.arrivalMsg,
-                              currentStation: subway.currentStation,
-                            ),
-                          )
-                          .toList(),
-                    ),
+                  : (_textEditingController.text.isNotEmpty &&
+                          viewModel.state.subwayInfos.isEmpty)
+                      ? const Center(
+                          child: Text(
+                            '존재하는 역 정보가 없습니다.\n역 이름을 다시 확인해주세요.',
+                            textAlign: TextAlign.center,
+                            style:
+                                TextStyle(fontSize: 16, color: Colors.black54),
+                          ),
+                        )
+                      : ListView(
+                          children: viewModel.state.subwayInfos
+                              .map(
+                                (subway) => SubwayInfoListTile(
+                                  subwayLine: subway.subwayLine.name,
+                                  direction: subway.direction,
+                                  arrivalMsg: subway.arrivalMsg,
+                                  currentStation: subway.currentStation,
+                                ),
+                              )
+                              .toList(),
+                        ),
             ),
           ],
         ),


### PR DESCRIPTION
일단 기본적으로 네트워크 문제가 아니라면 http의 response.statusCode 는 무조건 200. 따라서 이걸로 500을 가려낼 수 없음. 
정상적으로 역명을 검색했을때는 아래와 같이response.body를 jsonDecode했을 때  jsonData의 errorMessage의 status에 상태 코드가 넘어옴.
<img width="340" alt="image" src="https://github.com/user-attachments/assets/a69a7f60-d0e1-4545-b301-013bbec79ed2">

그런데, 통신은 잘 됐으나 잘못된 역명으로 검색한 경우엔 그냥  jsonData의 status에 상태코드가 넘어옴.
<img width="336" alt="image" src="https://github.com/user-attachments/assets/4d926a5a-cc30-40e5-b4d5-893b7cedcab3">


따라서 잘못된 역명으로 검색했을땐 터트리는게 아니라, null로 리턴해서 처리. 

null로 넘어간 데이터는 레포지토리에서 빈리스트로 처리하고, 최종적으로 ui에서는 역 명을 다시 확인 해달라는 메세지로 처리. 
